### PR TITLE
Handle missing "BatteryStatusRecords"

### DIFF
--- a/pycarwings2/pycarwings2.py
+++ b/pycarwings2/pycarwings2.py
@@ -369,7 +369,10 @@ class Leaf:
             "TimeFrom": self.bound_time
         })
         if response["status"] == 200:
-            return CarwingsLatestBatteryStatusResponse(response)
+            if "BatteryStatusRecords" in response:
+                return CarwingsLatestBatteryStatusResponse(response)
+            else:
+                log.warning('no battery status record returned by server')            
 
         return None
 


### PR DESCRIPTION
In case of a long time since requesting an update from the car the Nissan servers return just `{ "status": 200 }`.  Fix to avoid crash in this
instance.